### PR TITLE
Clean TODO for interface sort

### DIFF
--- a/__tests__/graphql/sort-sdl.spec.ts
+++ b/__tests__/graphql/sort-sdl.spec.ts
@@ -45,7 +45,7 @@ describe('sort-sdl', () => {
       expect(firstDirective?.name.value).toBe('a');
     });
 
-    test.skip('should sort interfaces for object types', () => {
+    test('should sort interfaces for object types', () => {
       const document = parse(`
                 interface C
                 interface B
@@ -53,8 +53,11 @@ describe('sort-sdl', () => {
                 type D implements C & B & A
                 `);
       const result = sortSDL(document);
-      const first = result.definitions[0] as ObjectTypeDefinitionNode;
-      const firstInterface = first.interfaces ? first.interfaces[0] : null; // FIXME: interfaces are empty array here
+      const first = result.definitions.find(
+        d => d.kind === 'ObjectTypeDefinition',
+      ) as ObjectTypeDefinitionNode;
+      const firstInterface = first.interfaces ? first.interfaces[0] : null;
+      expect(firstInterface?.name.value).toBe('A');
     });
   });
   describe('scalars', () => {

--- a/src/graphql/sort-sdl.ts
+++ b/src/graphql/sort-sdl.ts
@@ -46,7 +46,7 @@ export function sortSDL(doc: DocumentNode) {
           ...node,
           directives: sortNodes(node.directives),
           fields: sortNodes(node.fields),
-          // TODO: interfaces: sortNodes(node.interfaces),
+          interfaces: sortNodes(node.interfaces),
         };
       },
       InterfaceTypeDefinition(node) {


### PR DESCRIPTION
Interface sort works now as tests show, so it seems like we can clean out this TODO from the list.