### PR TITLE
A lot of fixes

### DIFF
--- a/.changeset/cold-keys-dream.md
+++ b/.changeset/cold-keys-dream.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Visit every field in provides and requires directives

--- a/.changeset/heavy-steaks-agree.md
+++ b/.changeset/heavy-steaks-agree.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Fix unnecessary join\_\_field(override:) on Query fields when it points to non-existing subgraph

--- a/.changeset/rich-sheep-hide.md
+++ b/.changeset/rich-sheep-hide.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Deduplicate composed directives

--- a/.changeset/silly-parents-smash.md
+++ b/.changeset/silly-parents-smash.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Remove duplicated link spec definitions

--- a/.changeset/thin-vans-chew.md
+++ b/.changeset/thin-vans-chew.md
@@ -1,0 +1,5 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Drop unused fields marked with @external only in a single type in Fed v1

--- a/__tests__/subgraph/link-directive.spec.ts
+++ b/__tests__/subgraph/link-directive.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { graphql, testVersions } from '../shared/testkit.js';
+import { assertCompositionSuccess, graphql, testVersions } from '../shared/testkit.js';
 
 testVersions((api, version) => {
   test('INVALID_LINK_IDENTIFIER', () => {
@@ -284,6 +284,44 @@ testVersions((api, version) => {
           }),
         ]),
       }),
+    );
+  });
+
+  test('remove duplicated link spec definitions', () => {
+    assertCompositionSuccess(
+      api.composeServices([
+        {
+          name: 'users',
+          typeDefs: graphql`
+            schema
+              @link(url: "https://specs.apollo.dev/link/v1.0")
+              @link(
+                url: "https://specs.apollo.dev/federation/${version}"
+                import: ["@shareable"]
+              ) {
+              query: Query
+            }
+
+            directive @link(
+              url: String!
+              as: String
+              for: link__Purpose
+              import: [link__Import]
+            ) repeatable on SCHEMA
+
+            scalar link__Import
+
+            enum link__Purpose {
+              SECURITY
+              EXECUTION
+            }
+
+            type Query {
+              foo: String
+            }
+          `,
+        },
+      ]),
     );
   });
 });

--- a/src/subgraph/validation/rules/elements/provides.ts
+++ b/src/subgraph/validation/rules/elements/provides.ts
@@ -262,10 +262,12 @@ export function ProvidesRules(context: SubgraphValidationContext): ASTVisitor {
                       info.typeDefinition.kind === Kind.OBJECT_TYPE_DEFINITION ||
                       info.typeDefinition.kind === Kind.OBJECT_TYPE_EXTENSION
                     ) {
-                      context.stateBuilder.objectType.field.markAsProvided(
-                        info.typeDefinition.name.value,
-                        info.fieldName,
-                      );
+                      if (info.fieldName !== '__typename') {
+                        context.stateBuilder.objectType.field.markAsProvided(
+                          info.typeDefinition.name.value,
+                          info.fieldName,
+                        );
+                      }
                     }
                   },
                 });

--- a/src/subgraph/validation/rules/elements/requires.ts
+++ b/src/subgraph/validation/rules/elements/requires.ts
@@ -125,10 +125,12 @@ export function RequiresRules(context: SubgraphValidationContext): ASTVisitor {
             info.typeDefinition.kind === Kind.OBJECT_TYPE_DEFINITION ||
             info.typeDefinition.kind === Kind.OBJECT_TYPE_EXTENSION
           ) {
-            context.stateBuilder.objectType.field.markedAsRequired(
-              info.typeDefinition.name.value,
-              info.fieldName,
-            );
+            if (info.fieldName !== '__typename') {
+              context.stateBuilder.objectType.field.markedAsRequired(
+                info.typeDefinition.name.value,
+                info.fieldName,
+              );
+            }
           }
         },
         interceptUnknownField(info) {


### PR DESCRIPTION
- Visit every field in provides and requires directives
- Fix unnecessary join__field(override:) on Query fields when it points to non-existing subgraph
- Deduplicate composed directives
- Remove duplicated link spec definitions
- Drop unused fields marked with @external only in a single type in Fed v1