### PR TITLE
fix: ignore inaccessible field argument for DEFAULT_VALUE_USES_INACCESSIBLE rule

### DIFF
--- a/.changeset/sharp-trees-sparkle.md
+++ b/.changeset/sharp-trees-sparkle.md
@@ -1,0 +1,20 @@
+---
+'@theguild/federation-composition': patch
+---
+
+Ignore inaccessible field arguments within the `DEFAULT_VALUE_USES_INACCESSIBLE` rule.
+
+Fixes an issue where an inaccessible field argument uses a default value that is inaccessible would
+cause a false error.
+
+```graphql
+type User @key(fields: "id") {
+  id: ID
+  friends(type: FriendType = FAMILY @inaccessible): [User!]!
+}
+
+enum FriendType {
+  FAMILY @inaccessible
+  FRIEND
+}
+```

--- a/__tests__/supergraph/errors/DEFAULT_VALUE_USES_INACCESSIBLE.spec.ts
+++ b/__tests__/supergraph/errors/DEFAULT_VALUE_USES_INACCESSIBLE.spec.ts
@@ -44,5 +44,34 @@ testVersions((api, version) => {
         ]),
       }),
     );
+
+    expect(
+      api.composeServices([
+        {
+          name: 'users',
+          typeDefs: graphql`
+          extend schema
+            @link(
+              url: "https://specs.apollo.dev/federation/${version}"
+              import: ["@key", "@inaccessible"]
+            )
+
+          type Query {
+            users: [User!]!
+          }
+
+          type User @key(fields: "id") {
+            id: ID
+            friends(type: FriendType = FAMILY @inaccessible): [User!]!
+          }
+
+          enum FriendType {
+            FAMILY @inaccessible
+            FRIEND
+          }
+         `,
+        },
+      ]),
+    ).toEqual(expect.objectContaining({ supergraphSdl: expect.any(String) }));
   });
 });

--- a/src/supergraph/validation/rules/default-value-uses-inaccessible-rule.ts
+++ b/src/supergraph/validation/rules/default-value-uses-inaccessible-rule.ts
@@ -26,6 +26,10 @@ export function DefaultValueUsesInaccessibleRule(
         return;
       }
 
+      if (argState.inaccessible) {
+        return;
+      }
+
       detectInaccessibleDefaultValue(
         context,
         () => `${objectState.name}.${fieldState.name}(${argState.name}:)`,


### PR DESCRIPTION

Ignore inaccessible field arguments within the `DEFAULT_VALUE_USES_INACCESSIBLE` rule.

Fixes an issue where an inaccessible field argument uses a default value that is inaccessible would
cause a false error.

```graphql
type User @key(fields: "id") {
  id: ID
  friends(type: FriendType = FAMILY @inaccessible): [User!]!
}

enum FriendType {
  FAMILY @inaccessible
  FRIEND
}
```