### PR TITLE
fix(transform-supergraph-to-public-schema): respect inaccessible enum values

### DIFF
--- a/.changeset/wicked-cows-hammer.md
+++ b/.changeset/wicked-cows-hammer.md
@@ -1,0 +1,5 @@
+---
+"@theguild/federation-composition": patch
+---
+
+Respect inaccessible enum values while creating the public schema from the supergraph AST

--- a/__tests__/graphql/transform-supergraph-to-public-schema.spec.ts
+++ b/__tests__/graphql/transform-supergraph-to-public-schema.spec.ts
@@ -31,6 +31,20 @@ describe('transformSupergraphToPublicSchema', () => {
         }"
       `);
     });
+    test('enum value removal', () => {
+      const sdl = parse(/* GraphQL */ `
+        enum Enum {
+          VALUE1 @inaccessible
+          VALUE2
+        }
+      `);
+      const resultSdl = transformSupergraphToPublicSchema(sdl);
+      expect(print(resultSdl)).toMatchInlineSnapshot(`
+        "enum Enum {
+          VALUE2
+        }"
+      `);
+    })
     test('object type removal', () => {
       const sdl = parse(/* GraphQL */ `
         type Object1 @inaccessible {

--- a/src/graphql/transform-supergraph-to-public-schema.ts
+++ b/src/graphql/transform-supergraph-to-public-schema.ts
@@ -131,6 +131,7 @@ export function transformSupergraphToPublicSchema(documentNode: DocumentNode): D
         return null;
       }
     },
+    [Kind.ENUM_VALUE_DEFINITION]: removeInaccessibleNode,
     [Kind.OBJECT_TYPE_DEFINITION]: removeInaccessibleNode,
     [Kind.FIELD_DEFINITION]: removeInaccessibleNode,
     [Kind.INTERFACE_TYPE_DEFINITION]: removeInaccessibleNode,


### PR DESCRIPTION
Remove enum values annotated with `@inaccessible` in the public schema